### PR TITLE
iOS build profile for ad-hoc now uses correct provisioning profile

### DIFF
--- a/src/DnnSummit.iOS/DnnSummit.iOS.csproj
+++ b/src/DnnSummit.iOS/DnnSummit.iOS.csproj
@@ -28,6 +28,7 @@
     <MtouchArch>x86_64</MtouchArch>
     <MtouchLink>None</MtouchLink>
     <MtouchDebug>true</MtouchDebug>
+    <CodesignKey>iPhone Developer</CodesignKey>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
     <DebugType>none</DebugType>
@@ -73,8 +74,8 @@
     <ConsolePause>False</ConsolePause>
     <MtouchArch>ARM64</MtouchArch>
     <BuildIpa>True</BuildIpa>
-    <CodesignProvision>Automatic:AdHoc</CodesignProvision>
-    <CodesignKey>iPhone Distribution</CodesignKey>
+    <CodesignProvision>Dnn Summit 2019 - Ad-Hoc</CodesignProvision>
+    <CodesignKey>iPhone Distribution: Hoefling Software, LLC (THNDUB728B)</CodesignKey>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'AppStore|iPhone' ">


### PR DESCRIPTION
* Added ad-hoc provisioning profile for internal testing