### PR TITLE
Offline Loading Screen

### DIFF
--- a/src/DnnSummit.Android/DnnSummit.Android.csproj
+++ b/src/DnnSummit.Android/DnnSummit.Android.csproj
@@ -29,6 +29,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AndroidLinkMode>None</AndroidLinkMode>
+    <AotAssemblies>false</AotAssemblies>
+    <EnableLLVM>false</EnableLLVM>
+    <BundleAssemblies>false</BundleAssemblies>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -39,6 +42,10 @@
     <WarningLevel>4</WarningLevel>
     <AndroidManagedSymbols>true</AndroidManagedSymbols>
     <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
+    <AotAssemblies>false</AotAssemblies>
+    <EnableLLVM>false</EnableLLVM>
+    <BundleAssemblies>false</BundleAssemblies>
+    <AndroidSupportedAbis>armeabi;armeabi-v7a;x86;x86_64;arm64-v8a</AndroidSupportedAbis>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Mono.Android" />

--- a/src/DnnSummit.Android/DnnSummit.Android.csproj
+++ b/src/DnnSummit.Android/DnnSummit.Android.csproj
@@ -32,6 +32,7 @@
     <AotAssemblies>false</AotAssemblies>
     <EnableLLVM>false</EnableLLVM>
     <BundleAssemblies>false</BundleAssemblies>
+    <AndroidSupportedAbis />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/DnnSummit.Data/Models/Settings.cs
+++ b/src/DnnSummit.Data/Models/Settings.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace DnnSummit.Data.Models
+{
+    public class Settings
+    {
+        public DateTime LastUpdated { get; set; }
+    }
+}

--- a/src/DnnSummit.Data/Services/Interfaces/ISettingsService.cs
+++ b/src/DnnSummit.Data/Services/Interfaces/ISettingsService.cs
@@ -1,0 +1,9 @@
+﻿using DnnSummit.Data.Models;
+
+namespace DnnSummit.Data.Services.Interfaces
+{
+    public interface ISettingsService
+    {
+        Settings Get();
+    }
+}

--- a/src/DnnSummit.Data/Services/SettingsService.cs
+++ b/src/DnnSummit.Data/Services/SettingsService.cs
@@ -1,0 +1,14 @@
+﻿using DnnSummit.Data.Models;
+using DnnSummit.Data.Services.Interfaces;
+using MonkeyCache.SQLite;
+
+namespace DnnSummit.Data.Services
+{
+    internal class SettingsService : ISettingsService
+    {
+        public Settings Get()
+        {
+            return Barrel.Current.Get<Settings>(nameof(Settings));
+        }
+    }
+}

--- a/src/DnnSummit.Data/Startup.cs
+++ b/src/DnnSummit.Data/Startup.cs
@@ -1,4 +1,5 @@
-﻿using DnnSummit.Data.Services;
+﻿using DnnSummit.Data.Models;
+using DnnSummit.Data.Services;
 using DnnSummit.Data.Services.Interfaces;
 using MonkeyCache.SQLite;
 using Prism.Ioc;
@@ -19,6 +20,7 @@ namespace DnnSummit.Data
             container.Register<IScheduleService, ScheduleService>();
             container.Register<ISpeakerService, SpeakerService>();
             container.Register<ISponsorService, SponsorService>();
+            container.Register<ISettingsService, SettingsService>();
         }
 
         public static void Initialize()
@@ -57,6 +59,9 @@ namespace DnnSummit.Data
                     // TODO - log error
                 }
             }
+
+            var settings = new Settings { LastUpdated = DateTime.UtcNow };
+            Barrel.Current.Add(nameof(Settings), settings, TimeSpan.FromDays(5));
         }
     }
 }

--- a/src/DnnSummit/App.xaml.cs
+++ b/src/DnnSummit/App.xaml.cs
@@ -14,8 +14,8 @@ namespace DnnSummit
 {
     public partial class App : PrismApplication
     {
-        public const string OfflineEntryPoint = "/" + Constants.Navigation.LoaddingOfflineModePage;
-        public const string InternetEntryPoint = "/" + Constants.Navigation.LoadingPage;
+        public const string OfflineLoading = "/" + Constants.Navigation.LoaddingOfflineModePage;
+        public const string InternetLoading = "/" + Constants.Navigation.LoadingPage;
         public const string EntryPoint = "/" + Constants.Navigation.NavigationPage + "/" + Constants.Navigation.TabbedPage;
 
         public App(IPlatformInitializer initializer = null) : base(initializer)
@@ -30,11 +30,11 @@ namespace DnnSummit
 
             if (Connectivity.NetworkAccess == NetworkAccess.Internet)
             {
-                NavigationService.NavigateAsync(InternetEntryPoint);
+                NavigationService.NavigateAsync(InternetLoading);
             }
             else
             {
-                NavigationService.NavigateAsync(OfflineEntryPoint);
+                NavigationService.NavigateAsync(OfflineLoading);
             }
         }
 

--- a/src/DnnSummit/App.xaml.cs
+++ b/src/DnnSummit/App.xaml.cs
@@ -14,8 +14,9 @@ namespace DnnSummit
 {
     public partial class App : PrismApplication
     {
-        public const string OfflineEntryPoint = "/" + Constants.Navigation.LoaddingOfflineModePage; ///Constants.Navigation.NavigationPage + "/" + Constants.Navigation.TabbedPage;
+        public const string OfflineEntryPoint = "/" + Constants.Navigation.LoaddingOfflineModePage;
         public const string InternetEntryPoint = "/" + Constants.Navigation.LoadingPage;
+        public const string EntryPoint = "/" + Constants.Navigation.NavigationPage + "/" + Constants.Navigation.TabbedPage;
 
         public App(IPlatformInitializer initializer = null) : base(initializer)
         {

--- a/src/DnnSummit/App.xaml.cs
+++ b/src/DnnSummit/App.xaml.cs
@@ -14,8 +14,8 @@ namespace DnnSummit
 {
     public partial class App : PrismApplication
     {
-        public const string Dashboard = "/" + Constants.Navigation.NavigationPage + "/" + Constants.Navigation.TabbedPage;
-        public const string EntryPoint = "/" + Constants.Navigation.LoadingPage;
+        public const string OfflineEntryPoint = "/" + Constants.Navigation.LoaddingOfflineModePage; ///Constants.Navigation.NavigationPage + "/" + Constants.Navigation.TabbedPage;
+        public const string InternetEntryPoint = "/" + Constants.Navigation.LoadingPage;
 
         public App(IPlatformInitializer initializer = null) : base(initializer)
         {
@@ -29,11 +29,11 @@ namespace DnnSummit
 
             if (Connectivity.NetworkAccess == NetworkAccess.Internet)
             {
-                NavigationService.NavigateAsync(EntryPoint);
+                NavigationService.NavigateAsync(InternetEntryPoint);
             }
             else
             {
-                NavigationService.NavigateAsync(Dashboard);
+                NavigationService.NavigateAsync(OfflineEntryPoint);
             }
         }
 
@@ -47,6 +47,7 @@ namespace DnnSummit
         private void RegisterNavigation(IContainerRegistry containerRegistry)
         {
             containerRegistry.RegisterForNavigation<LoadingPage>(Constants.Navigation.LoadingPage);
+            containerRegistry.RegisterForNavigation<LoadingOfflineModePage>(Constants.Navigation.LoaddingOfflineModePage);
             containerRegistry.RegisterForNavigation<DnnSummitNavigationPage>(Constants.Navigation.NavigationPage);
             containerRegistry.RegisterForNavigation<DnnSummitTabbedPage>(Constants.Navigation.TabbedPage);
             containerRegistry.RegisterForNavigation<LocationPage>(Constants.Navigation.LocationPage);

--- a/src/DnnSummit/Constants.cs
+++ b/src/DnnSummit/Constants.cs
@@ -5,6 +5,7 @@
         public static class Navigation
         {
             public const string LoadingPage = "LoadingPage";
+            public const string LoaddingOfflineModePage = "LoadingOfflineModePage";
             public const string NavigationPage = "NavigationPage";
             public const string TabbedPage = "TabbedPage";
             public const string LocationPage = "LocationPage";

--- a/src/DnnSummit/DnnSummit.csproj
+++ b/src/DnnSummit/DnnSummit.csproj
@@ -39,6 +39,9 @@
     <EmbeddedResource Update="Views\InfoPage.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
+    <EmbeddedResource Update="Views\LoadingOfflineModePage.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
     <EmbeddedResource Update="Views\LoadingPage.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>

--- a/src/DnnSummit/ViewModels/LoadingOfflineModeViewModel.cs
+++ b/src/DnnSummit/ViewModels/LoadingOfflineModeViewModel.cs
@@ -1,0 +1,28 @@
+﻿using Prism.Mvvm;
+using Prism.Navigation;
+using System;
+
+namespace DnnSummit.ViewModels
+{
+    public class LoadingOfflineModeViewModel : BindableBase, INavigatingAware
+    {
+        private const string OfflineMessage_Pattern = "Unable to update content, information current as of {0}, Contact event staff for any change or retry with internet.";
+
+        private string _message;
+        public string Message
+        {
+            get { return _message; }
+            set
+            {
+                SetProperty(ref _message, value);
+                RaisePropertyChanged(nameof(Message));
+            }
+        }
+
+        public void OnNavigatingTo(INavigationParameters parameters)
+        {
+            var date = DateTime.Now.ToString("MM/dd/yyyy");
+            Message = string.Format(OfflineMessage_Pattern, date);
+        }
+    }
+}

--- a/src/DnnSummit/ViewModels/LoadingOfflineModeViewModel.cs
+++ b/src/DnnSummit/ViewModels/LoadingOfflineModeViewModel.cs
@@ -3,6 +3,7 @@ using Prism.Commands;
 using Prism.Mvvm;
 using Prism.Navigation;
 using Prism.Services;
+using System;
 using System.Windows.Input;
 using Xamarin.Essentials;
 
@@ -40,6 +41,7 @@ namespace DnnSummit.ViewModels
         }
 
         public ICommand DownloadContent { get; }
+        public ICommand Continue { get; }
 
         public LoadingOfflineModeViewModel(
             ISettingsService settingsService,
@@ -50,6 +52,15 @@ namespace DnnSummit.ViewModels
             PageDialogService = pageDialogService;
             NavigationService = navigationService;
             DownloadContent = new DelegateCommand(OnDownloadContent);
+            Continue = new DelegateCommand(OnContinue);
+        }
+
+        private async void OnContinue()
+        {
+            if (!IsNoData)
+            {
+                await NavigationService.NavigateAsync(App.EntryPoint);
+            }
         }
 
         private async void OnDownloadContent()

--- a/src/DnnSummit/ViewModels/LoadingOfflineModeViewModel.cs
+++ b/src/DnnSummit/ViewModels/LoadingOfflineModeViewModel.cs
@@ -1,12 +1,15 @@
-﻿using Prism.Mvvm;
+﻿using DnnSummit.Data.Services.Interfaces;
+using Prism.Mvvm;
 using Prism.Navigation;
-using System;
 
 namespace DnnSummit.ViewModels
 {
     public class LoadingOfflineModeViewModel : BindableBase, INavigatingAware
     {
         private const string OfflineMessage_Pattern = "Unable to update content, information current as of {0}, Contact event staff for any change or retry with internet.";
+        private const string NoDataMessage = "Unable to download content, retry with internet or contact event staff.";
+
+        protected ISettingsService SettingsService { get; }
 
         private string _message;
         public string Message
@@ -19,10 +22,37 @@ namespace DnnSummit.ViewModels
             }
         }
 
+        private bool _isNoData = false;
+        public bool IsNoData
+        {
+            get { return _isNoData; }
+            set
+            {
+                SetProperty(ref _isNoData, value);
+                RaisePropertyChanged(nameof(IsNoData));
+            }
+        }
+
+        public LoadingOfflineModeViewModel(ISettingsService settingsService)
+        {
+            SettingsService = settingsService;
+        }
+
         public void OnNavigatingTo(INavigationParameters parameters)
         {
-            var date = DateTime.Now.ToString("MM/dd/yyyy");
-            Message = string.Format(OfflineMessage_Pattern, date);
+            var settings = SettingsService.Get();
+
+            if (settings != null)
+            {
+                IsNoData = false;
+                var date = settings.LastUpdated.ToLocalTime().ToString("MM/dd/yyyy");
+                Message = string.Format(OfflineMessage_Pattern, date);
+            }
+            else
+            {
+                IsNoData = true;
+                Message = NoDataMessage;
+            }
         }
     }
 }

--- a/src/DnnSummit/ViewModels/LoadingOfflineModeViewModel.cs
+++ b/src/DnnSummit/ViewModels/LoadingOfflineModeViewModel.cs
@@ -4,6 +4,9 @@ using Prism.Mvvm;
 using Prism.Navigation;
 using Prism.Services;
 using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using System.Timers;
 using System.Windows.Input;
 using Xamarin.Essentials;
 
@@ -75,7 +78,7 @@ namespace DnnSummit.ViewModels
             }
         }
 
-        public void OnNavigatingTo(INavigationParameters parameters)
+        public async void OnNavigatingTo(INavigationParameters parameters)
         {
             var settings = SettingsService.Get();
 
@@ -84,6 +87,9 @@ namespace DnnSummit.ViewModels
                 IsNoData = false;
                 var date = settings.LastUpdated.ToLocalTime().ToString("MM/dd/yyyy");
                 Message = string.Format(OfflineMessage_Pattern, date);
+
+                await Task.Delay(5000);
+                OnContinue();
             }
             else
             {

--- a/src/DnnSummit/ViewModels/LoadingOfflineModeViewModel.cs
+++ b/src/DnnSummit/ViewModels/LoadingOfflineModeViewModel.cs
@@ -3,10 +3,7 @@ using Prism.Commands;
 using Prism.Mvvm;
 using Prism.Navigation;
 using Prism.Services;
-using System;
-using System.Diagnostics;
 using System.Threading.Tasks;
-using System.Timers;
 using System.Windows.Input;
 using Xamarin.Essentials;
 

--- a/src/DnnSummit/ViewModels/LoadingOfflineModeViewModel.cs
+++ b/src/DnnSummit/ViewModels/LoadingOfflineModeViewModel.cs
@@ -1,6 +1,10 @@
 ﻿using DnnSummit.Data.Services.Interfaces;
+using Prism.Commands;
 using Prism.Mvvm;
 using Prism.Navigation;
+using Prism.Services;
+using System.Windows.Input;
+using Xamarin.Essentials;
 
 namespace DnnSummit.ViewModels
 {
@@ -10,6 +14,8 @@ namespace DnnSummit.ViewModels
         private const string NoDataMessage = "Unable to download content, retry with internet or contact event staff.";
 
         protected ISettingsService SettingsService { get; }
+        protected IPageDialogService PageDialogService { get; }
+        protected INavigationService NavigationService { get; }
 
         private string _message;
         public string Message
@@ -33,9 +39,29 @@ namespace DnnSummit.ViewModels
             }
         }
 
-        public LoadingOfflineModeViewModel(ISettingsService settingsService)
+        public ICommand DownloadContent { get; }
+
+        public LoadingOfflineModeViewModel(
+            ISettingsService settingsService,
+            IPageDialogService pageDialogService,
+            INavigationService navigationService)
         {
             SettingsService = settingsService;
+            PageDialogService = pageDialogService;
+            NavigationService = navigationService;
+            DownloadContent = new DelegateCommand(OnDownloadContent);
+        }
+
+        private async void OnDownloadContent()
+        {
+            if (Connectivity.NetworkAccess == NetworkAccess.Internet)
+            {
+                await NavigationService.NavigateAsync(App.InternetLoading);
+            }
+            else
+            {
+                await PageDialogService.DisplayAlertAsync("No Internet", "Unable to download content, no internet detected.", "OK");
+            }
         }
 
         public void OnNavigatingTo(INavigationParameters parameters)

--- a/src/DnnSummit/ViewModels/LoadingViewModel.cs
+++ b/src/DnnSummit/ViewModels/LoadingViewModel.cs
@@ -48,7 +48,7 @@ namespace DnnSummit.ViewModels
 
         private async Task FinishAndNavigateAsync()
         {            
-            await NavigationService.NavigateAsync(App.OfflineEntryPoint);
+            await NavigationService.NavigateAsync(App.EntryPoint);
         }
 
         private void OnProgressUpdated(object sender, EventArgs e)

--- a/src/DnnSummit/ViewModels/LoadingViewModel.cs
+++ b/src/DnnSummit/ViewModels/LoadingViewModel.cs
@@ -48,7 +48,7 @@ namespace DnnSummit.ViewModels
 
         private async Task FinishAndNavigateAsync()
         {            
-            await NavigationService.NavigateAsync(App.Dashboard);
+            await NavigationService.NavigateAsync(App.OfflineEntryPoint);
         }
 
         private void OnProgressUpdated(object sender, EventArgs e)

--- a/src/DnnSummit/Views/LoadingOfflineModePage.xaml
+++ b/src/DnnSummit/Views/LoadingOfflineModePage.xaml
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="DnnSummit.Views.LoadingOfflineModePage">
+    <ContentPage.Content>
+        <StackLayout>
+            <Image Source="splash_icon"
+                   VerticalOptions="CenterAndExpand"
+                   HorizontalOptions="CenterAndExpand" />
+            <Label Text="Unable to update content, information current as of xx/xx/xxxx, Contact event staff for any change or retry with internet."
+                   FontSize="20"
+                   TextColor="White"
+                   VerticalOptions="CenterAndExpand" 
+                   HorizontalOptions="CenterAndExpand" />
+        </StackLayout>
+    </ContentPage.Content>
+</ContentPage>

--- a/src/DnnSummit/Views/LoadingOfflineModePage.xaml
+++ b/src/DnnSummit/Views/LoadingOfflineModePage.xaml
@@ -5,6 +5,9 @@
              x:Class="DnnSummit.Views.LoadingOfflineModePage">
     <ContentPage.Content>
         <StackLayout>
+            <StackLayout.GestureRecognizers>
+                <TapGestureRecognizer Command="{Binding Continue}" />
+            </StackLayout.GestureRecognizers>
             <Image Source="splash_icon"
                    VerticalOptions="CenterAndExpand"
                    HorizontalOptions="CenterAndExpand" />

--- a/src/DnnSummit/Views/LoadingOfflineModePage.xaml
+++ b/src/DnnSummit/Views/LoadingOfflineModePage.xaml
@@ -15,6 +15,14 @@
                    VerticalOptions="StartAndExpand" 
                    HorizontalTextAlignment="Center"
                    HorizontalOptions="CenterAndExpand" />
+            <Button Text="Download Content"
+                    TextColor="White"
+                    FontSize="20"
+                    IsVisible="{Binding IsNoData}"
+                    BackgroundColor="{StaticResource DarkBlue}"
+                    VerticalOptions="StartAndExpand"
+                    HorizontalOptions="CenterAndExpand"
+                    Margin="20,0"/>
         </StackLayout>
     </ContentPage.Content>
 </ContentPage>

--- a/src/DnnSummit/Views/LoadingOfflineModePage.xaml
+++ b/src/DnnSummit/Views/LoadingOfflineModePage.xaml
@@ -16,6 +16,7 @@
                    HorizontalTextAlignment="Center"
                    HorizontalOptions="CenterAndExpand" />
             <Button Text="Download Content"
+                    Command="{Binding DownloadContent}"
                     TextColor="White"
                     FontSize="20"
                     IsVisible="{Binding IsNoData}"

--- a/src/DnnSummit/Views/LoadingOfflineModePage.xaml
+++ b/src/DnnSummit/Views/LoadingOfflineModePage.xaml
@@ -8,7 +8,7 @@
             <Image Source="splash_icon"
                    VerticalOptions="CenterAndExpand"
                    HorizontalOptions="CenterAndExpand" />
-            <Label Text="Unable to update content, information current as of xx/xx/xxxx, Contact event staff for any change or retry with internet."
+            <Label Text="{Binding Message}"
                    FontSize="24"
                    Margin="10,0"
                    TextColor="White"

--- a/src/DnnSummit/Views/LoadingOfflineModePage.xaml
+++ b/src/DnnSummit/Views/LoadingOfflineModePage.xaml
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             BackgroundColor="{StaticResource SplashBackground}"
              x:Class="DnnSummit.Views.LoadingOfflineModePage">
     <ContentPage.Content>
         <StackLayout>
@@ -8,9 +9,11 @@
                    VerticalOptions="CenterAndExpand"
                    HorizontalOptions="CenterAndExpand" />
             <Label Text="Unable to update content, information current as of xx/xx/xxxx, Contact event staff for any change or retry with internet."
-                   FontSize="20"
+                   FontSize="24"
+                   Margin="10,0"
                    TextColor="White"
-                   VerticalOptions="CenterAndExpand" 
+                   VerticalOptions="StartAndExpand" 
+                   HorizontalTextAlignment="Center"
                    HorizontalOptions="CenterAndExpand" />
         </StackLayout>
     </ContentPage.Content>

--- a/src/DnnSummit/Views/LoadingOfflineModePage.xaml.cs
+++ b/src/DnnSummit/Views/LoadingOfflineModePage.xaml.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace DnnSummit.Views
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class LoadingOfflineModePage : ContentPage
+	{
+		public LoadingOfflineModePage ()
+		{
+			InitializeComponent ();
+		}
+	}
+}


### PR DESCRIPTION
Added an offline loading screen and workflows to handle offline edge cases:

## Offline (No Data)
Given a user has never downloaded any content.
When the user opens the app
Then the user is brought to a no data screen
Then the user has the option to download content when they have internet

![image](https://user-images.githubusercontent.com/17751436/50371339-ae53e100-0586-11e9-8e26-6eaab042ed5c.png)

![image](https://user-images.githubusercontent.com/17751436/50371342-b3b12b80-0586-11e9-9220-ea506f75fe32.png)

## Offline (Cached Data)
Given a user has downloaded the content at least once
When the user opens the app
Then the user is brought to an offline data screen

This screen will disappear automatically after 5000ms. If the user taps anywhere on the screen it will continue on to the dashboard.

![image](https://user-images.githubusercontent.com/17751436/50371351-e9561480-0586-11e9-8362-2a9c3905066e.png)


Fixes: #42 #35