### PR TITLE
Added defensive code to handle situations where the speaker.Sessions …

### DIFF
--- a/src/DnnSummit.Data/Services/SpeakerService.cs
+++ b/src/DnnSummit.Data/Services/SpeakerService.cs
@@ -26,30 +26,38 @@ namespace DnnSummit.Data.Services
                     {
                         Name = item.Title,
                         Bio = item.Bio,
-                        Twitter = item.Twitter,
-                        Sessions = item.Sessions
-                           .Select(s => sessions[s.Id])
-                           .Select(s => new Session
-                           {
-                               Title = s.Title,
-                               Abstract = s.Abstract,
-                               Description = s.Description,
-                               Day = s.Day,
-                               TimeSlot = s.TimeSlot,
-                               TimeSlotName = s.TimeSlot,
-                               Category = s.Category,
-                               VideoLink = s.VideoLink,
-                               Level = s.Level,
-                               Room = s.Room
-                           })
+                        Twitter = item.Twitter
                     };
 
+                    var speakerSessions = new List<Session>();
+                    foreach (var currentSession in item.Sessions)
+                    {
+                        if (sessions.ContainsKey(currentSession.Id))
+                        {
+                            var s = sessions[currentSession.Id];
+                            speakerSessions.Add(new Session
+                            {
+                                Title = s.Title,
+                                Abstract = s.Abstract,
+                                Description = s.Description,
+                                Day = s.Day,
+                                TimeSlot = s.TimeSlot,
+                                TimeSlotName = s.TimeSlot,
+                                Category = s.Category,
+                                VideoLink = s.VideoLink,
+                                Level = s.Level,
+                                Room = s.Room
+                            });
+                        }
+                    }
+
+                    current.Sessions = speakerSessions;
                     current.Photo = await GetImageFromUrlAsync($"https://www.dnnsummit.org{item.Photo}");
                     return current;
                 })));
             }
 
-            return await Task.WhenAll(results);
+            return Task.WhenAll(results).GetAwaiter().GetResult();
         }
     }
 }

--- a/src/DnnSummit/ViewModels/SpeakersViewModel.cs
+++ b/src/DnnSummit/ViewModels/SpeakersViewModel.cs
@@ -47,6 +47,8 @@ namespace DnnSummit.ViewModels
         public async void OnNavigatingTo(INavigationParameters parameters)
         {
             var data = await SpeakerService.GetAsync();
+            if (data == null) return;
+
             Speakers.Clear();
             foreach (var item in data)
             {


### PR DESCRIPTION
…don't match the published session list. Added a return if speaker data is null so the app doesn't crash if we are unable to pull the data for whatever reason

fixes: #60 