### PR TITLE
Added Offline Timestamps

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,7 @@ resources:
   repositories:
     - repository: Templates
       type: github
-      ref: 'refs/heads/master'
+      ref: 'refs/heads/mastr'
       name: "HoeflingSoftware/DevOps.Templates"
       endpoint: DNNAssociation
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,7 @@ resources:
   repositories:
     - repository: Templates
       type: github
-      ref: 'refs/heads/master'
+      ref: 'refs/tags/v0.0.0'
       name: "HoeflingSoftware/DevOps.Templates"
       endpoint: DNNAssociation
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,7 @@ resources:
   repositories:
     - repository: Templates
       type: github
-      ref: 'refs/tags/v0.0.0'
+      ref: 'refs/heads/master'
       name: "HoeflingSoftware/DevOps.Templates"
       endpoint: DNNAssociation
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,7 @@ resources:
   repositories:
     - repository: Templates
       type: github
-      ref: 'refs/heads/mastr'
+      ref: 'refs/heads/master'
       name: "HoeflingSoftware/DevOps.Templates"
       endpoint: DNNAssociation
 

--- a/src/DnnSummit.Data/Models/Entity.cs
+++ b/src/DnnSummit.Data/Models/Entity.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace DnnSummit.Data.Models
+{
+    public class Entity
+    {
+        public DateTime Retrieved { get; set; }
+    }
+}

--- a/src/DnnSummit.Data/Models/ScheduleDetails.cs
+++ b/src/DnnSummit.Data/Models/ScheduleDetails.cs
@@ -2,7 +2,7 @@
 
 namespace DnnSummit.Data.Models
 {
-    public class ScheduleDetails
+    public class ScheduleDetails : Entity
     {
         public string Title { get; set; }
         public string CardDescription { get; set; }

--- a/src/DnnSummit.Data/Models/Session.cs
+++ b/src/DnnSummit.Data/Models/Session.cs
@@ -1,7 +1,7 @@
 ﻿namespace DnnSummit.Data.Models
 {
-    public class Session
-    {
+    public class Session : Entity
+    { 
         public string Title { get; set; }
         public string Abstract { get; set; }
         public string Description { get; set; }

--- a/src/DnnSummit.Data/Services/ScheduleService.cs
+++ b/src/DnnSummit.Data/Services/ScheduleService.cs
@@ -48,6 +48,7 @@ namespace DnnSummit.Data.Services
                         BannerTitle = day.BannerTitle,
                         BannerHeading = day.BannerHeading,
                         BannerImage = await GetImageFromUrlAsync($"https://www.dnnsummit.org{day.BannerImage}"),
+                        Retrieved = DateTime.Now,
                         Sections = publishedSections
                     };
                 })));

--- a/src/DnnSummit.Data/Services/SessionService.cs
+++ b/src/DnnSummit.Data/Services/SessionService.cs
@@ -32,7 +32,8 @@ namespace DnnSummit.Data.Services
                         VideoLink = item.VideoLink,
                         Category = item.Category,
                         Level = item.Level,
-                        Room = item.Room
+                        Room = item.Room,
+                        Retrieved = DateTime.Now
                     };
 
                     // TODO - Update the model to return many speakers instead of taking just 1

--- a/src/DnnSummit/App.xaml
+++ b/src/DnnSummit/App.xaml
@@ -53,6 +53,7 @@
             <converters:NotTrueConverter x:Key="NotTrueConverter" />
             <converters:IsNotStringNullOrEmptyConverter x:Key="IsNotStringNullOrEmptyConverter" />
             <converters:PercentToStringConverter x:Key="PercentToStringConverter" />
+            <converters:DataTimestampConverter x:Key="DataTimestampConverter" />
         </ResourceDictionary>
     </Application.Resources>
 </prism:PrismApplication>

--- a/src/DnnSummit/Constants.cs
+++ b/src/DnnSummit/Constants.cs
@@ -13,5 +13,10 @@
             public const string SessionDetailsPage = "SessionDetailsPage";
             public const string SponsorsPage = "SponsorsPage";
         }
+
+        public static class Messages
+        {
+            public const string LastRetrieved = "Last Retrieved: {0}";
+        }
     }
 }

--- a/src/DnnSummit/Converters/DataTimestampConverter.cs
+++ b/src/DnnSummit/Converters/DataTimestampConverter.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Globalization;
+using Xamarin.Forms;
+
+namespace DnnSummit.Converters
+{
+    public class DataTimestampConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var timestamp = (DateTime)value;
+
+            return string.Format(Constants.Messages.LastRetrieved, timestamp.ToString("MM/dd/yyyy @ h:mm tt")); 
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/DnnSummit/Converters/DataTimestampConverter.cs
+++ b/src/DnnSummit/Converters/DataTimestampConverter.cs
@@ -10,7 +10,7 @@ namespace DnnSummit.Converters
         {
             var timestamp = (DateTime)value;
 
-            return string.Format(Constants.Messages.LastRetrieved, timestamp.ToString("MM/dd/yyyy @ h:mm tt")); 
+            return string.Format(Constants.Messages.LastRetrieved, timestamp.ToString("MM/dd/yy @ h:mm tt")); 
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/src/DnnSummit/Converters/TypeToImageConverter.cs
+++ b/src/DnnSummit/Converters/TypeToImageConverter.cs
@@ -1,5 +1,4 @@
 ﻿using DnnSummit.Attributes;
-using DnnSummit.Models;
 using System;
 using System.Globalization;
 using Xamarin.Forms;

--- a/src/DnnSummit/Models/Event.cs
+++ b/src/DnnSummit/Models/Event.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace DnnSummit.Models
 {
@@ -10,5 +11,6 @@ namespace DnnSummit.Models
         public ScheduleType Avatar { get; set; }
         public (string Heading, string SubHeading, byte[] Image) Banner { get; set; }
         public IEnumerable<ScheduleContent> ContentSections { get; set; }
+        public DateTime Retrieved { get; set; }
     }
 }

--- a/src/DnnSummit/Models/Session.cs
+++ b/src/DnnSummit/Models/Session.cs
@@ -1,4 +1,5 @@
 ﻿using Prism.Mvvm;
+using System;
 
 namespace DnnSummit.Models
 {
@@ -100,6 +101,17 @@ namespace DnnSummit.Models
             {
                 SetProperty(ref _videoLink, value);
                 RaisePropertyChanged(nameof(VideoLink));
+            }
+        }
+
+        private DateTime _retrieved;
+        public DateTime Retrieved
+        {
+            get { return _retrieved; }
+            set
+            {
+                SetProperty(ref _retrieved, value);
+                RaisePropertyChanged(nameof(Retrieved));
             }
         }
     }

--- a/src/DnnSummit/ViewModels/ScheduleDetailsViewModel.cs
+++ b/src/DnnSummit/ViewModels/ScheduleDetailsViewModel.cs
@@ -72,8 +72,30 @@ namespace DnnSummit.ViewModels
             }
         }
 
+        private bool _displayOfflineNotice;
+        public bool DisplayOfflineNotice
+        {
+            get { return _displayOfflineNotice; }
+            set
+            {
+                SetProperty(ref _displayOfflineNotice, value);
+                RaisePropertyChanged(nameof(DisplayOfflineNotice));
+            }
+        }
+
+        private DateTime _contentRetrieved;
+        public DateTime ContentRetrieved
+        {
+            get { return _contentRetrieved; }
+            set
+            {
+                SetProperty(ref _contentRetrieved, value);
+                RaisePropertyChanged(nameof(ContentRetrieved));
+            }
+        }
 
         public ICommand VideoSelected { get; }
+        public ICommand ToggleOfflineNotice { get; }
 
         public ObservableCollection<ScheduleContent> ContentSections { get; set; }
 
@@ -83,8 +105,15 @@ namespace DnnSummit.ViewModels
         {
             PageDialogService = pageDialogService;
             ScheduleService = scheduleService;
+            DisplayOfflineNotice = true;
             ContentSections = new ObservableCollection<ScheduleContent>();
             VideoSelected = new DelegateCommand<string>(OnVideoSelected);
+            ToggleOfflineNotice = new DelegateCommand(OnToggleOfflineNotice);
+        }
+
+        private void OnToggleOfflineNotice()
+        {
+            DisplayOfflineNotice = !DisplayOfflineNotice;
         }
 
         private async void OnVideoSelected(string link)
@@ -101,7 +130,7 @@ namespace DnnSummit.ViewModels
             }
         }
 
-        public async void OnNavigatingTo(INavigationParameters parameters)
+        public void OnNavigatingTo(INavigationParameters parameters)
         {
             bool isSuccessful = false;
             if (parameters.ContainsKey(nameof(Event)))
@@ -114,6 +143,7 @@ namespace DnnSummit.ViewModels
                     Heading = details.Banner.Heading;
                     SubHeading = details.Banner.SubHeading;
                     Image = ImageSource.FromStream(() => new MemoryStream(details.Banner.Image));
+                    ContentRetrieved = details.Retrieved;
 
                     ContentSections.Clear();
                     foreach (var item in details.ContentSections)

--- a/src/DnnSummit/ViewModels/ScheduleViewModel.cs
+++ b/src/DnnSummit/ViewModels/ScheduleViewModel.cs
@@ -56,6 +56,7 @@ namespace DnnSummit.ViewModels
                     Description = item.CardDescription,
                     Avatar = item.Title.ToScheduleType(),
                     Banner = (item.BannerTitle, item.BannerHeading, item.BannerImage),
+                    Retrieved = item.Retrieved,
                     ContentSections = item.Sections.Select(x => new ScheduleContent
                     {
                         Title = x.Title,

--- a/src/DnnSummit/ViewModels/SessionDetailsViewModel.cs
+++ b/src/DnnSummit/ViewModels/SessionDetailsViewModel.cs
@@ -110,6 +110,17 @@ namespace DnnSummit.ViewModels
             }
         }
 
+        private DateTime _contentRetrieved;
+        public DateTime ContentRetrieved
+        {
+            get { return _contentRetrieved; }
+            set
+            {
+                SetProperty(ref _contentRetrieved, value);
+                RaisePropertyChanged(nameof(ContentRetrieved));
+            }
+        }
+
         public bool HasVideoIntro
         {
             get { return !string.IsNullOrWhiteSpace(VideoIntroLink); }
@@ -148,6 +159,7 @@ namespace DnnSummit.ViewModels
                     TimeSlot = session.TimeSlot;
                     SessionTrack = session.Track;
                     VideoIntroLink = session.VideoLink;
+                    ContentRetrieved = session.Retrieved;
 
                     isSuccessful = true;
                 }

--- a/src/DnnSummit/ViewModels/SessionDetailsViewModel.cs
+++ b/src/DnnSummit/ViewModels/SessionDetailsViewModel.cs
@@ -154,7 +154,9 @@ namespace DnnSummit.ViewModels
         public SessionDetailsViewModel()
         {
             DisplayOfflineNotice = true;
-            VideoIntroMargin = new Thickness(0, 0, 0, 55);
+            VideoIntroMargin = Device.RuntimePlatform == Device.iOS ?
+                new Thickness(0, 0, 0, 75) :
+                new Thickness(0, 0, 0, 55);
             VideoIntro = new DelegateCommand(OnVideoIntro);
             ToggleOfflineNotice = new DelegateCommand(OnToggleOfflineNotice);
         }
@@ -165,11 +167,15 @@ namespace DnnSummit.ViewModels
 
             if (DisplayOfflineNotice)
             {
-                VideoIntroMargin = new Thickness(0, 0, 0, 55);
+                VideoIntroMargin = Device.RuntimePlatform == Device.iOS ?
+                    new Thickness(0, 0, 0, 75) :
+                    new Thickness(0, 0, 0, 55);
             }
             else
             {
-                VideoIntroMargin = new Thickness(0, 0, 0, 10);
+                VideoIntroMargin = Device.RuntimePlatform == Device.iOS ?
+                    new Thickness(0, 0, 0, 30) :
+                    new Thickness(0, 0, 0, 10);
             }
         }
 

--- a/src/DnnSummit/ViewModels/SessionDetailsViewModel.cs
+++ b/src/DnnSummit/ViewModels/SessionDetailsViewModel.cs
@@ -121,16 +121,56 @@ namespace DnnSummit.ViewModels
             }
         }
 
+        private bool _displayOfflineNotice;
+        public bool DisplayOfflineNotice
+        {
+            get { return _displayOfflineNotice; }
+            set
+            {
+                SetProperty(ref _displayOfflineNotice, value);
+                RaisePropertyChanged(nameof(DisplayOfflineNotice));
+            }
+        }
+
+        private Thickness _videoIntroMargin;
+        public Thickness VideoIntroMargin
+        {
+            get { return _videoIntroMargin; }
+            set
+            {
+                SetProperty(ref _videoIntroMargin, value);
+                RaisePropertyChanged(nameof(VideoIntroMargin));
+            }
+        }
+
         public bool HasVideoIntro
         {
             get { return !string.IsNullOrWhiteSpace(VideoIntroLink); }
         }
 
         public ICommand VideoIntro { get; }
+        public ICommand ToggleOfflineNotice { get; }
 
         public SessionDetailsViewModel()
         {
+            DisplayOfflineNotice = true;
+            VideoIntroMargin = new Thickness(0, 0, 0, 55);
             VideoIntro = new DelegateCommand(OnVideoIntro);
+            ToggleOfflineNotice = new DelegateCommand(OnToggleOfflineNotice);
+        }
+
+        private void OnToggleOfflineNotice()
+        {
+            DisplayOfflineNotice = !DisplayOfflineNotice;
+
+            if (DisplayOfflineNotice)
+            {
+                VideoIntroMargin = new Thickness(0, 0, 0, 55);
+            }
+            else
+            {
+                VideoIntroMargin = new Thickness(0, 0, 0, 10);
+            }
         }
 
         private void OnVideoIntro()

--- a/src/DnnSummit/ViewModels/SessionsViewModel.cs
+++ b/src/DnnSummit/ViewModels/SessionsViewModel.cs
@@ -102,6 +102,7 @@ namespace DnnSummit.ViewModels
                             TimeSlotName = x.TimeSlotName,
                             TimeSlot = x.TimeSlot,
                             VideoLink = x.VideoLink,
+                            Retrieved = x.Retrieved,
                             Speaker = new Speaker
                             {
                                 Name = x.Speaker.Name,

--- a/src/DnnSummit/ViewModels/SessionsViewModel.cs
+++ b/src/DnnSummit/ViewModels/SessionsViewModel.cs
@@ -24,6 +24,7 @@ namespace DnnSummit.ViewModels
         public ICommand SessionSelected { get; }
         public ICommand SwapState { get; }
         public ICommand ToggleAsFavorite { get; }
+        public ICommand ToggleOfflineNotice { get; }
 
         public ObservableCollection<SessionList> Sessions { get; }
 
@@ -60,19 +61,58 @@ namespace DnnSummit.ViewModels
             }
         }
 
+        private bool _displayOfflineNotice;
+        public bool DisplayOfflineNotice
+        {
+            get { return _displayOfflineNotice; }
+            set
+            {
+                SetProperty(ref _displayOfflineNotice, value);
+                RaisePropertyChanged(nameof(DisplayOfflineNotice));
+            }
+        }
+
+        private Thickness _floatingButtonMargin;
+        public Thickness FloatingButtonMargin
+        {
+            get { return _floatingButtonMargin; }
+            set
+            {
+                SetProperty(ref _floatingButtonMargin, value);
+                RaisePropertyChanged(nameof(FloatingButtonMargin));
+            }
+        }
+
         public SessionsViewModel(
             INavigationService navigationService,
             ISessionService sessionService)
         {
             IsViewingFavoriteSessions = false;
             IsBusy = false;
+            DisplayOfflineNotice = true;
+            FloatingButtonMargin = new Thickness(0, 0, 10, 45);
             NavigationService = navigationService;
             SessionService = sessionService;
             SessionSelected = new DelegateCommand<Session>(OnSessionSelected);
             SwapState = new DelegateCommand(OnSwapState);
             ToggleAsFavorite = new DelegateCommand<Session>(OnToggleAsFavorite);
+            ToggleOfflineNotice = new DelegateCommand(OnToggleOfflineNotice);
             Sessions = new ObservableCollection<SessionList>();
             
+        }
+
+        private void OnToggleOfflineNotice()
+        {
+            DisplayOfflineNotice = !DisplayOfflineNotice;
+
+            if (DisplayOfflineNotice)
+            {
+                FloatingButtonMargin = new Thickness(0, 0, 10, 45);
+            }
+            else
+            {
+                FloatingButtonMargin = new Thickness(0, 0, 10, 10);
+            }
         }
 
         private void OnToggleAsFavorite(Session session)

--- a/src/DnnSummit/ViewModels/SessionsViewModel.cs
+++ b/src/DnnSummit/ViewModels/SessionsViewModel.cs
@@ -49,6 +49,17 @@ namespace DnnSummit.ViewModels
             }
         }
 
+        private DateTime _contentRetrieved;
+        public DateTime ContentRetrieved
+        {
+            get { return _contentRetrieved; }
+            set
+            {
+                SetProperty(ref _contentRetrieved, value);
+                RaisePropertyChanged(nameof(ContentRetrieved));
+            }
+        }
+
         public SessionsViewModel(
             INavigationService navigationService,
             ISessionService sessionService)
@@ -117,6 +128,8 @@ namespace DnnSummit.ViewModels
             {
                 Sessions.Add(item);
             }
+
+            ContentRetrieved = rawSessions.FirstOrDefault().Retrieved;
         }
 
         public async void OnNavigatingTo(INavigationParameters parameters)

--- a/src/DnnSummit/Views/ScheduleDetailsPage.xaml
+++ b/src/DnnSummit/Views/ScheduleDetailsPage.xaml
@@ -62,35 +62,58 @@
         </ResourceDictionary>
     </ContentPage.Resources>
     <ContentPage.Content>
-        <StackLayout Spacing="0">
-            <Grid HorizontalOptions="FillAndExpand">
-                <Image Source="{Binding Image}"
-                       VerticalOptions="Start"
-                       Aspect="AspectFill"
-                       HorizontalOptions="FillAndExpand" />
-                <StackLayout Orientation="Vertical"
-                             Spacing="0"
-                             VerticalOptions="CenterAndExpand"
-                             HorizontalOptions="CenterAndExpand">
-                    <Label Text="{Binding Heading}"
-                           TextColor="White"
-                           FontSize="20"
-                           FontAttributes="Bold"
-                           VerticalTextAlignment="Center"
-                           HorizontalTextAlignment="Center" />
-                    <Label Text="{Binding SubHeading}"
-                           TextColor="White"
-                           FontSize="16"
-                           VerticalTextAlignment="Center"
-                           HorizontalTextAlignment="Center" />
-                </StackLayout>
-            </Grid>
-            <ListView ItemsSource="{Binding ContentSections}"
-                      ItemTemplate="{StaticResource ContentTemplate}"
-                      SeparatorColor="Transparent"
-                      SeparatorVisibility="None"
-                      HasUnevenRows="True"
-                      ItemTapped="ListView_ItemTapped" />    
-        </StackLayout>
+        <Grid>
+            <StackLayout Spacing="0">
+                <Grid HorizontalOptions="FillAndExpand">
+                    <Image Source="{Binding Image}"
+                           VerticalOptions="Start"
+                           Aspect="AspectFill"
+                           HorizontalOptions="FillAndExpand" />
+                    <StackLayout Orientation="Vertical"
+                                 Spacing="0"
+                                 VerticalOptions="CenterAndExpand"
+                                 HorizontalOptions="CenterAndExpand">
+                        <Label Text="{Binding Heading}"
+                               TextColor="White"
+                               FontSize="20"
+                               FontAttributes="Bold"
+                               VerticalTextAlignment="Center"
+                               HorizontalTextAlignment="Center" />
+                        <Label Text="{Binding SubHeading}"
+                               TextColor="White"
+                               FontSize="16"
+                               VerticalTextAlignment="Center"
+                               HorizontalTextAlignment="Center" />
+                    </StackLayout>
+                </Grid>
+                <ListView ItemsSource="{Binding ContentSections}"
+                          ItemTemplate="{StaticResource ContentTemplate}"
+                          SeparatorColor="Transparent"
+                          SeparatorVisibility="None"
+                          HasUnevenRows="True"
+                          ItemTapped="ListView_ItemTapped" />    
+            </StackLayout>
+            <StackLayout HorizontalOptions="Fill"
+                         VerticalOptions="End"
+                         Padding="5,10"
+                         Margin="0, 0, 0, -2"
+                         Spacing="0"
+                         BackgroundColor="{StaticResource Orange}"
+                         Orientation="Horizontal"
+                         IsVisible="{Binding DisplayOfflineNotice}">
+                <Label Text="{Binding ContentRetrieved, Converter={StaticResource DataTimestampConverter}}"
+                       TextColor="White"
+                       HorizontalOptions="Start"/>
+                <Label HorizontalOptions="EndAndExpand"
+                       Text="Hide"
+                       TextColor="White"
+                       FontAttributes="Bold"
+                       Margin="0,0,10,0">
+                    <Label.GestureRecognizers>
+                        <TapGestureRecognizer Command="{Binding ToggleOfflineNotice}" />
+                    </Label.GestureRecognizers>
+                </Label>
+            </StackLayout>
+        </Grid>
     </ContentPage.Content>
 </ContentPage>

--- a/src/DnnSummit/Views/ScheduleDetailsPage.xaml
+++ b/src/DnnSummit/Views/ScheduleDetailsPage.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:c="clr-namespace:DnnSummit.Controls"
@@ -108,7 +108,7 @@
                        Text="Hide"
                        TextColor="White"
                        FontAttributes="Bold"
-                       Margin="0,0,10,0">
+                       Margin="{OnPlatform Android='0,0,10,0', iOS='0,0,10,25'}">
                     <Label.GestureRecognizers>
                         <TapGestureRecognizer Command="{Binding ToggleOfflineNotice}" />
                     </Label.GestureRecognizers>

--- a/src/DnnSummit/Views/SessionDetailsPage.xaml
+++ b/src/DnnSummit/Views/SessionDetailsPage.xaml
@@ -108,10 +108,15 @@
                              Color="{StaticResource ListDivider}" />
                     </StackLayout>
                     <ScrollView Orientation="Vertical"
-                            Padding="10, 0, 10, 65">
-                        <Label Text="{Binding Description}"
-                           TextColor="Black"
-                           FontSize="24"/>
+                                Padding="10, 0, 10, 65">
+                        <StackLayout Spacing="20">
+                            <Label Text="{Binding Description}"
+                                   TextColor="Black"
+                                   FontSize="24"/>
+                            <Label Text="{Binding ContentRetrieved, Converter={StaticResource DataTimestampConverter}}"
+                                   TextColor="Black"
+                                   FontSize="18" />
+                        </StackLayout>
                     </ScrollView>
                 </StackLayout>
             </StackLayout>

--- a/src/DnnSummit/Views/SessionDetailsPage.xaml
+++ b/src/DnnSummit/Views/SessionDetailsPage.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:c="clr-namespace:DnnSummit.Controls"
@@ -150,7 +150,7 @@
                        Text="Hide"
                        TextColor="White"
                        FontAttributes="Bold"
-                       Margin="0,0,10,0">
+                       Margin="{OnPlatform Android='0,0,10,0', iOS='0,0,10,25'}">
                     <Label.GestureRecognizers>
                         <TapGestureRecognizer Command="{Binding ToggleOfflineNotice}" />
                     </Label.GestureRecognizers>

--- a/src/DnnSummit/Views/SessionDetailsPage.xaml
+++ b/src/DnnSummit/Views/SessionDetailsPage.xaml
@@ -109,14 +109,9 @@
                     </StackLayout>
                     <ScrollView Orientation="Vertical"
                                 Padding="10, 0, 10, 65">
-                        <StackLayout Spacing="20">
-                            <Label Text="{Binding Description}"
-                                   TextColor="Black"
-                                   FontSize="24"/>
-                            <Label Text="{Binding ContentRetrieved, Converter={StaticResource DataTimestampConverter}}"
-                                   TextColor="Black"
-                                   FontSize="18" />
-                        </StackLayout>
+                        <Label Text="{Binding Description}"
+                               TextColor="Black"
+                               FontSize="24"/>
                     </ScrollView>
                 </StackLayout>
             </StackLayout>
@@ -124,7 +119,7 @@
                    IsEnabled="{Binding HasVideoIntro}"
                    VerticalOptions="End"
                    HorizontalOptions="CenterAndExpand"
-                   Margin="0, 0, 0, 15"
+                   Margin="{Binding VideoIntroMargin}"
                    Padding="10"
                    BackgroundColor="{Binding SessionTrack, Converter={StaticResource SessionTrackToColorConverter}}">
                 <Frame.GestureRecognizers>
@@ -140,6 +135,27 @@
                            VerticalTextAlignment="Center"/>
                 </StackLayout>
             </Frame>
+            <StackLayout HorizontalOptions="Fill"
+                         VerticalOptions="End"
+                         Padding="5,10"
+                         Margin="0, 0, 0, -2"
+                         Spacing="0"
+                         BackgroundColor="{StaticResource Orange}"
+                         Orientation="Horizontal"
+                         IsVisible="{Binding DisplayOfflineNotice}">
+                <Label Text="{Binding ContentRetrieved, Converter={StaticResource DataTimestampConverter}}"
+                       TextColor="White"
+                       HorizontalOptions="Start"/>
+                <Label HorizontalOptions="EndAndExpand"
+                       Text="Hide"
+                       TextColor="White"
+                       FontAttributes="Bold"
+                       Margin="0,0,10,0">
+                    <Label.GestureRecognizers>
+                        <TapGestureRecognizer Command="{Binding ToggleOfflineNotice}" />
+                    </Label.GestureRecognizers>
+                </Label>
+            </StackLayout>
         </Grid>
     </ContentPage.Content>
 </ContentPage>

--- a/src/DnnSummit/Views/SessionsPage.xaml
+++ b/src/DnnSummit/Views/SessionsPage.xaml
@@ -168,7 +168,7 @@
                         Text="Day 2" />
                 </StackLayout>
             </Frame>
-            <Frame Margin="0, 0, 10, 10"
+            <Frame Margin="0, 0, 10, 45"
                    VerticalOptions="End"
                    HorizontalOptions="End"
                    HeightRequest="50"
@@ -199,6 +199,16 @@
                            IsVisible="{Binding IsViewingFavoriteSessions}" />
                 </StackLayout>                
             </Frame>
+            <StackLayout HorizontalOptions="Fill"
+                         VerticalOptions="End"
+                         Padding="5,10"
+                         Margin="0, 0, 0, -2"
+                         Spacing="0"
+                         BackgroundColor="{StaticResource Orange}">
+                <Label Text="{Binding ContentRetrieved, Converter={StaticResource DataTimestampConverter}}"
+                       TextColor="White"
+                       HorizontalOptions="Start"/>    
+            </StackLayout>            
         </Grid>
     </ContentPage.Content>
 </ContentPage>

--- a/src/DnnSummit/Views/SessionsPage.xaml
+++ b/src/DnnSummit/Views/SessionsPage.xaml
@@ -168,7 +168,7 @@
                         Text="Day 2" />
                 </StackLayout>
             </Frame>
-            <Frame Margin="0, 0, 10, 45"
+            <Frame Margin="{Binding FloatingButtonMargin}"
                    VerticalOptions="End"
                    HorizontalOptions="End"
                    HeightRequest="50"
@@ -204,10 +204,21 @@
                          Padding="5,10"
                          Margin="0, 0, 0, -2"
                          Spacing="0"
-                         BackgroundColor="{StaticResource Orange}">
+                         BackgroundColor="{StaticResource Orange}"
+                         Orientation="Horizontal"
+                         IsVisible="{Binding DisplayOfflineNotice}">
                 <Label Text="{Binding ContentRetrieved, Converter={StaticResource DataTimestampConverter}}"
                        TextColor="White"
-                       HorizontalOptions="Start"/>    
+                       HorizontalOptions="Start"/>
+                <Label HorizontalOptions="EndAndExpand"
+                       Text="Hide"
+                       TextColor="White"
+                       FontAttributes="Bold"
+                       Margin="0,0,10,0">
+                    <Label.GestureRecognizers>
+                        <TapGestureRecognizer Command="{Binding ToggleOfflineNotice}" />
+                    </Label.GestureRecognizers>
+                </Label>
             </StackLayout>            
         </Grid>
     </ContentPage.Content>


### PR DESCRIPTION
Added offline timestamp notices to the following pages:

* Sessions
* Session Details
* Schedule Details

The notice can be hidden by tapping the hide button

closes: #43 

## Screenshots:

### Android
![image](https://user-images.githubusercontent.com/17751436/51812725-c94dfb00-2280-11e9-826d-0d64ddbf5805.png)

![image](https://user-images.githubusercontent.com/17751436/51812737-d5d25380-2280-11e9-83de-eee4329d270e.png)

![image](https://user-images.githubusercontent.com/17751436/51812746-e1257f00-2280-11e9-8506-2e4be4563f9f.png)

### iOS

<img width="432" alt="screen shot 2019-01-27 at 10 15 02 pm" src="https://user-images.githubusercontent.com/17751436/51812842-44171600-2281-11e9-9470-abc9011a87f8.png">

<img width="450" alt="screen shot 2019-01-27 at 10 15 30 pm" src="https://user-images.githubusercontent.com/17751436/51812846-48433380-2281-11e9-83ac-a118cdc366e7.png">

<img width="449" alt="screen shot 2019-01-27 at 10 15 38 pm" src="https://user-images.githubusercontent.com/17751436/51812849-4c6f5100-2281-11e9-9f1e-5f69c14e61f2.png">



